### PR TITLE
Add serial port assistant page and navigation item

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -50,6 +50,8 @@ namespace SAcom
                 services.AddSingleton<DashboardViewModel>();
                 services.AddSingleton<DataPage>();
                 services.AddSingleton<DataViewModel>();
+                services.AddSingleton<SerialPortPage>();
+                services.AddSingleton<SerialPortViewModel>();
                 services.AddSingleton<SettingsPage>();
                 services.AddSingleton<SettingsViewModel>();
             }).Build();

--- a/ViewModels/Pages/SerialPortViewModel.cs
+++ b/ViewModels/Pages/SerialPortViewModel.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Wpf.Ui.Abstractions.Controls;
+
+namespace SAcom.ViewModels.Pages
+{
+    public partial class SerialPortViewModel : ObservableObject, INavigationAware
+    {
+        public Task OnNavigatedToAsync() => Task.CompletedTask;
+
+        public Task OnNavigatedFromAsync() => Task.CompletedTask;
+    }
+}

--- a/ViewModels/Windows/MainWindowViewModel.cs
+++ b/ViewModels/Windows/MainWindowViewModel.cs
@@ -22,6 +22,12 @@ namespace SAcom.ViewModels.Windows
                 Content = "Data",
                 Icon = new SymbolIcon { Symbol = SymbolRegular.DataHistogram24 },
                 TargetPageType = typeof(Views.Pages.DataPage)
+            },
+            new NavigationViewItem()
+            {
+                Content = "串口助手",
+                Icon = new SymbolIcon { Symbol = SymbolRegular.PlugConnected24 },
+                TargetPageType = typeof(Views.Pages.SerialPortPage)
             }
         };
 

--- a/Views/Pages/SerialPortPage.xaml
+++ b/Views/Pages/SerialPortPage.xaml
@@ -1,0 +1,25 @@
+<Page
+    x:Class="SAcom.Views.Pages.SerialPortPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:SAcom.Views.Pages"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="SerialPortPage"
+    d:DataContext="{d:DesignInstance local:SerialPortPage, IsDesignTimeCreatable=False}"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+    ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    mc:Ignorable="d">
+
+    <Grid>
+        <TextBlock
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            FontSize="24"
+            Text="串口助手" />
+    </Grid>
+</Page>

--- a/Views/Pages/SerialPortPage.xaml.cs
+++ b/Views/Pages/SerialPortPage.xaml.cs
@@ -1,0 +1,18 @@
+using SAcom.ViewModels.Pages;
+using Wpf.Ui.Abstractions.Controls;
+
+namespace SAcom.Views.Pages
+{
+    public partial class SerialPortPage : INavigableView<SerialPortViewModel>
+    {
+        public SerialPortViewModel ViewModel { get; }
+
+        public SerialPortPage(SerialPortViewModel viewModel)
+        {
+            ViewModel = viewModel;
+            DataContext = this;
+
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Serial Port Assistant page and view model
- Register new page in DI container and navigation menu
- Add sidebar navigation entry labeled "串口助手"

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a577e5d8f88321973f0a8fa6e5ebbb